### PR TITLE
Add projection and encoding parameters to WriteAllFeatures() method

### DIFF
--- a/src/NetTopologySuite.IO.Esri.Shapefile/Dbf/DbfReader.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Dbf/DbfReader.cs
@@ -235,6 +235,7 @@ namespace NetTopologySuite.IO.Esri.Dbf
                 Fields[i].ReadValue(Buffer);
             }
 
+            PrintRecordBytes(CurrentIndex, Buffer);
             CurrentIndex++;
             return true;
         }
@@ -301,6 +302,28 @@ namespace NetTopologySuite.IO.Esri.Dbf
             CurrentIndex = index;
             Read(out var _);
             return Fields.ToAttributesTable();
+        }
+
+        [Conditional("DEBUG_DBF")]
+        private void PrintRecordBytes(int recordIndex, MemoryStream recordData)
+        {
+            var data = recordData.ToArray();
+            Debug.WriteLine($"Record {recordIndex}");
+
+            var deletedName = "<deleted>";
+            var deletedFlag = Encoding.GetString(data, 0, 1);
+            Debug.WriteLine($"{deletedName,32}: `{deletedFlag}`");
+
+            int dataIndex = 1;
+            for (int i = 0; i < Fields.Count; i++)
+            {
+                var field = Fields[i];
+                var fieldData = Encoding
+                    .GetString(data, dataIndex, field.Length)
+                    .Replace(char.MinValue, '▬'); // Make NULL visible
+
+                Debug.WriteLine($"{field.Name,32}: `{fieldData}`");
+            }
         }
 
         #region IEnumerable

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shapefile.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shapefile.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Esri.Shapefiles.Readers;
@@ -190,7 +191,9 @@ namespace NetTopologySuite.IO.Esri
         /// </summary>
         /// <param name="features">Features to be written.</param>
         /// <param name="shpPath">Path to shapefile.</param>
-        public static void WriteAllFeatures(IEnumerable<IFeature> features, string shpPath)
+        /// <param name="projection">Projection metadata for the shapefile (content of the PRJ file).</param>
+        /// <param name="encoding">DBF file encoding (if not set UTF8 is used).</param>
+        public static void WriteAllFeatures(IEnumerable<IFeature> features, string shpPath, string projection = null, Encoding encoding = null)
         {
             if (features == null)
                 throw new ArgumentNullException(nameof(features));
@@ -201,7 +204,11 @@ namespace NetTopologySuite.IO.Esri
 
             var fields = firstFeature.Attributes.GetDbfFields();
             var shapeType = features.FindNonEmptyGeometry().GetShapeType();
-            var options = new ShapefileWriterOptions(shapeType, fields);
+            var options = new ShapefileWriterOptions(shapeType, fields)
+            {
+                Projection = projection,
+                Encoding = encoding
+            };
 
             using (var shpWriter = OpenWrite(shpPath, options))
             {

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Readers/ShapefileReader.T.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Readers/ShapefileReader.T.cs
@@ -1,11 +1,8 @@
-﻿using NetTopologySuite.Features;
+﻿using System.IO;
+using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Esri.Dbf;
-using NetTopologySuite.IO.Esri.Dbf.Fields;
 using NetTopologySuite.IO.Esri.Shp.Readers;
-using System;
-using System.IO;
-using System.Text;
 
 namespace NetTopologySuite.IO.Esri.Shapefiles.Readers
 {
@@ -139,9 +136,7 @@ namespace NetTopologySuite.IO.Esri.Shapefiles.Readers
         protected override void DisposeManagedResources()
         {
             ShpReader?.Dispose();
-            DbfReader?.Dispose();
-
-            base.DisposeManagedResources(); // This will dispose streams used by ShpReader and DbfReader. Do it at the end.
+            base.DisposeManagedResources(); 
         }
 
         internal abstract ShpReader<T> CreateShpReader(Stream shpStream, ShapefileReaderOptions options);

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Readers/ShapefileReader.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Readers/ShapefileReader.cs
@@ -1,11 +1,11 @@
-﻿using NetTopologySuite.Features;
-using NetTopologySuite.Geometries;
-using NetTopologySuite.IO.Esri.Dbf;
-using NetTopologySuite.IO.Esri.Dbf.Fields;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Esri.Dbf;
+using NetTopologySuite.IO.Esri.Dbf.Fields;
 
 namespace NetTopologySuite.IO.Esri.Shapefiles.Readers
 {
@@ -106,6 +106,13 @@ namespace NetTopologySuite.IO.Esri.Shapefiles.Readers
                 return Read();
             }
             return read;
+        }
+
+        /// <inheritdoc/>
+        protected override void DisposeManagedResources()
+        {
+            DbfReader?.Dispose();
+            base.DisposeManagedResources(); 
         }
 
         #region *** Enumerator ***

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Writers/ShapefileWriter.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Writers/ShapefileWriter.cs
@@ -56,6 +56,13 @@ namespace NetTopologySuite.IO.Esri.Shapefiles.Writers
                 Write(feature);
             }
         }
+
+        /// <inheritdoc/>
+        protected override void DisposeManagedResources()
+        {
+            DbfWriter?.Dispose();
+            base.DisposeManagedResources(); // This will dispose streams used by DbfReader. Do it at the end. We need to store DBF header first.
+        }
     }
 
 

--- a/test/NetTopologySuite.IO.Esri.Test/Issues/Issue016.cs
+++ b/test/NetTopologySuite.IO.Esri.Test/Issues/Issue016.cs
@@ -1,0 +1,104 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NetTopologySuite.IO.Esri.Dbf.Fields;
+using NetTopologySuite.IO.Esri.Shapefiles.Writers;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NetTopologySuite.IO.Esri.Test.Issues
+{
+    /// <summary>
+    /// https://github.com/NetTopologySuite/NetTopologySuite.IO.Esri/issues/16
+    /// </summary>
+    internal class Issue016
+    {
+        [Test]
+        public void StoreProjectionUsingWriter()
+        {
+            var geoReader = new GeoJsonReader();
+            var features = geoReader.Read<FeatureCollection>(GeoJsonData);
+
+            var prop0 = new DbfCharacterField("prop0");
+            var prop1 = new DbfCharacterField("prop1");
+            var options = new ShapefileWriterOptions(ShapeType.Polygon, prop0, prop1)
+            {
+                Projection = @"GEOGCS[""GCS_WGS_1984"",DATUM[""D_WGS_1984"",SPHEROID[""WGS_1984"",6378137.0,298.257223563]],PRIMEM[""Greenwich"",0.0],UNIT[""Degree"",0.0174532925199433]]"
+            };
+
+            var shpPath = TestShapefiles.GetTempShpPath(); // "C:\\Temp\\Issue016.shp";
+            using (var shpWriter = Shapefile.OpenWrite(shpPath, options))
+            {
+                shpWriter.Write(features);
+            }
+
+            using (var shpReader = Shapefile.OpenRead(shpPath))
+            {
+                Assert.AreEqual(features.Count, shpReader.RecordCount);
+                Assert.AreEqual(options.Projection, shpReader.Projection);
+            }
+
+            TestShapefiles.DeleteShp(shpPath);
+        }
+
+        [Test]
+        public void StoreProjectionWriteAllFeaturesMethod()
+        {
+            var geoReader = new GeoJsonReader();
+            var features = geoReader.Read<FeatureCollection>(GeoJsonData);
+
+            var projection = @"GEOGCS[""GCS_WGS_1984"",DATUM[""D_WGS_1984"",SPHEROID[""WGS_1984"",6378137.0,298.257223563]],PRIMEM[""Greenwich"",0.0],UNIT[""Degree"",0.0174532925199433]]";
+            var shpPath = TestShapefiles.GetTempShpPath();
+            Shapefile.WriteAllFeatures(features, shpPath, projection);
+
+            using (var shpReader = Shapefile.OpenRead(shpPath))
+            {
+                Assert.AreEqual(features.Count, shpReader.RecordCount);
+                Assert.AreEqual(projection, shpReader.Projection);
+            }
+
+            TestShapefiles.DeleteShp(shpPath);
+        }
+
+        #region Data
+
+        /// <summary>
+        /// Credits to Wikipedia.
+        /// <seealso cref="https://en.wikipedia.org/wiki/GeoJSON"/>
+        /// </summary>
+        private static readonly string GeoJsonData = @"
+                {
+                  ""type"": ""FeatureCollection"",
+                  ""features"": [
+                    {
+                      ""type"": ""Feature"",
+                      ""geometry"": {
+                        ""type"": ""MultiPolygon"",
+                        ""coordinates"": [
+                            [
+                                [[40.0, 40.0], [20.0, 45.0], [45.0, 30.0], [40.0, 40.0]]
+                            ], 
+                            [
+                                [[20.0, 35.0], [10.0, 30.0], [10.0, 10.0], [30.0, 5.0], [45.0, 20.0], [20.0, 35.0]], 
+                                [[30.0, 20.0], [20.0, 15.0], [20.0, 25.0], [30.0, 20.0]]
+                            ]
+                        ]
+                      },
+                      ""properties"": {
+                        ""prop0"": ""value0"",
+                        ""prop1"": ""that"" 
+                      }
+                    }
+                  ]
+                }
+            ";
+
+        #endregion
+    }
+}

--- a/test/NetTopologySuite.IO.Esri.Test/NetTopologySuite.IO.Esri.Test.csproj
+++ b/test/NetTopologySuite.IO.Esri.Test/NetTopologySuite.IO.Esri.Test.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="3.0.0" />
     <PackageReference Include="QuickGraph" Version="3.6.61119.7" NoWarn="NU1701" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Add `projection` and `encoding` parameters to commonly used `WriteAllFeatures()` method.
- Add [missing ](https://github.com/NetTopologySuite/NetTopologySuite.IO.Esri/blob/338411d9706830be2bef6bc5fa2b6032e69cf0ed/src/NetTopologySuite.IO.Esri.Shapefile/Shapefiles/Writers/ShapefileWriter.cs#L61) `DbfStream` disposing and clean up `DbfStream` related code.
- Add `DBF_DEBUG` mode (related to #11).