### PR TITLE
Do not write SHP files that are over 2GB. Fix #42.

### DIFF
--- a/src/NetTopologySuite.IO.Esri.Shapefile/Dbf/DbfWriter.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Dbf/DbfWriter.cs
@@ -179,6 +179,7 @@ namespace NetTopologySuite.IO.Esri.Dbf
             {
                 Fields[i].WriteValue(DbfStream);
             }
+            Shapefile.ValidateComponentSize(DbfStream.Length);
             RecordCount++;
         }
 

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shapefile.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shapefile.cs
@@ -24,6 +24,10 @@ namespace NetTopologySuite.IO.Esri
         internal const int FileHeaderSize = 100;
         internal const int RecordHeaderSize = 2 * sizeof(int);
 
+        // There is a 2 GB size limit for any shapefile component file
+        // https://desktop.arcgis.com/en/arcmap/latest/manage-data/shapefiles/geoprocessing-considerations-for-shapefile-output.htm
+        private const long GB = 1024 * 1024 * 1024;
+        private const long MaxComponentSize = 2 * GB; 
 
         /// <summary>
         /// Minimal Measure value considered as not "no-data".
@@ -326,6 +330,19 @@ namespace NetTopologySuite.IO.Esri
             using (var shpWriter = OpenWrite(shpPath, options))
             {
                 shpWriter.Write(features);
+            }
+        }
+
+        /// <summary>
+        /// Validates a 2 GB size limit for any shapefile component file.
+        /// </summary>
+        /// <param name="size">Shapefile component file size.</param>
+        /// <exception cref="ShapefileException"></exception>
+        internal static void ValidateComponentSize(long size)
+        {
+            if (size > MaxComponentSize)
+            {
+                throw new ShapefileException($"Shapefile component file size exceeded 2GB limit.");
             }
         }
 

--- a/src/NetTopologySuite.IO.Esri.Shapefile/Shp/Writers/ShpWriter.cs
+++ b/src/NetTopologySuite.IO.Esri.Shapefile/Shp/Writers/ShpWriter.cs
@@ -70,6 +70,9 @@ namespace NetTopologySuite.IO.Esri.Shp.Writers
             ShpStream.WriteShpRecordHeader(RecordNumber, (int)Buffer.Length);
             ShpStream.WriteAllBytes(Buffer);
 
+            Shapefile.ValidateComponentSize(ShxStream.Length);
+            Shapefile.ValidateComponentSize(ShpStream.Length);
+
             RecordNumber++;
         }
 

--- a/test/NetTopologySuite.IO.Esri.Test/Issues/Issue042.cs
+++ b/test/NetTopologySuite.IO.Esri.Test/Issues/Issue042.cs
@@ -1,0 +1,76 @@
+﻿using NetTopologySuite.IO.Esri.Dbf.Fields;
+using NetTopologySuite.IO.Esri.Shapefiles.Writers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetTopologySuite.IO.Esri.Test.Issues;
+
+/// <summary>
+/// https://github.com/NetTopologySuite/NetTopologySuite.IO.Esri/issues/42
+/// </summary>
+internal class Issue042
+{
+    private const long GB = 1024 * 1024 * 1024;
+    private const long MB = 1024 * 1024;
+
+    [Test]
+    public void CreateShapefile_1MB_Success()
+    {
+        string shpPath = TestShapefiles.GetTempShpPath();
+        (long shpSize, int featureCount) = CreateShapefile(1 * MB, shpPath);
+        Console.WriteLine($"Feature count: {featureCount}");
+        Console.WriteLine($"SHP size:      {shpSize}");
+        TestShapefiles.DeleteShp(shpPath);
+    }
+
+    [Test]
+    public void CreateShapefile_2GB_Error()
+    {
+        string shpPath = @"D:\Temp\CreateShapefile_2GB_Error.shp";
+        if (Directory.Exists(Path.GetDirectoryName(shpPath))) // Do not create 2GB files during pipeline tests.
+        {
+            long geometrySize = 399;
+            long minShpSize = 2 * GB + geometrySize;
+            Assert.Throws<ShapefileException>(() => CreateShapefile(minShpSize, shpPath));
+        }
+    }
+
+    [Test]
+    public void CreateShapefile_2GB_Success()
+    {
+        string shpPath = @"D:\Temp\CreateShapefile_2GB_Success.shp";
+        if (Directory.Exists(Path.GetDirectoryName(shpPath))) // Do not create 2GB files during pipeline tests.
+        {
+            long geometrySize = 399;
+            long minShpSize = 2 * GB - geometrySize;
+            (long shpSize, int featureCount) = CreateShapefile(minShpSize, shpPath);
+            Console.WriteLine($"Feature count: {featureCount}");
+            Console.WriteLine($"SHP size:      {shpSize}");
+        }
+    }
+
+    private static (long shpSize, int featureCount) CreateShapefile(long minSzie, string shpPath)
+    {
+        var fields = new List<DbfField>();
+        var fidField = fields.AddNumericInt32Field("fid");
+        var fid = 1;
+
+        var options = new ShapefileWriterOptions(ShapeType.Polygon, fields.ToArray());
+
+        using var shpStream = File.OpenWrite(shpPath);
+        using var shxStream = File.OpenWrite(Path.ChangeExtension(shpPath, ".shx"));
+        using var dbfStream = File.OpenWrite(Path.ChangeExtension(shpPath, ".dbf"));
+        using var shpWriter = Shapefile.OpenWrite(shpStream, shxStream, dbfStream, null, options);
+
+        while (shpStream.Length < minSzie)
+        {
+            shpWriter.Geometry = SampleGeometry.SampleMultiPolygonWithHole;
+            fidField.NumericValue = fid++;
+            shpWriter.Write();
+        }
+
+        return (shpStream.Length, fid - 1);
+    }
+}

--- a/test/NetTopologySuite.IO.Esri.Test/SampleGeometry.cs
+++ b/test/NetTopologySuite.IO.Esri.Test/SampleGeometry.cs
@@ -1,0 +1,29 @@
+﻿using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using System.Collections.Generic;
+
+namespace NetTopologySuite.IO.Esri.Test;
+
+internal class SampleGeometry
+{
+    private static readonly GeometryFactory _geomFactory = NtsGeometryServices.Instance.CreateGeometryFactory(5432);
+    private static readonly WKTReader _reader = new WKTReader(_geomFactory);
+
+    public static Geometry EmptyPoint { get; } = _reader.Read("POINT EMPTY");
+    public static Geometry EmptyMultiPoint { get; } = _reader.Read("MULTIPOINT EMPTY");
+    public static Geometry EmptyLineString { get; } = _reader.Read("LINESTRING EMPTY");
+    public static Geometry EmptyMultiLineString { get; } = _reader.Read("MULTILINESTRING EMPTY");
+    public static Geometry EmptyPolygon { get; } = _reader.Read("POLYGON EMPTY");
+    public static Geometry EmptyMultiPolygon { get; } = _reader.Read("MULTIPOLYGON EMPTY");
+
+    // Credits to: https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
+    public static Geometry SamplePoint { get; } = _reader.Read("POINT (30 10)");
+    public static Geometry SampleMultiPoint { get; } = _reader.Read("MULTIPOINT ((10 40), (40 30), (20 20),(30 10))");
+    public static Geometry SampleLineString { get; } = _reader.Read("LINESTRING (30 10, 10 30, 40 40)");
+    public static Geometry SampleMultiLineString { get; } = _reader.Read("MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))");
+    public static Geometry SamplePolygon { get; } = _reader.Read("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))");
+    public static Geometry SamplePolygonWithHole { get; } = _reader.Read("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))");
+    public static Geometry SampleMultiPolygon { get; } = _reader.Read("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))");
+    public static Geometry SampleMultiPolygonWithHole { get; } = _reader.Read("MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),((20 35, 10 30, 10 10, 30 5, 45 20, 20 35),(30 20, 20 15, 20 25, 30 20)))");
+
+}


### PR DESCRIPTION
Handle 2GB shapefile limits.

> There is a 2 GB size limit for any shapefile component file, which translates to a maximum of roughly 70 million point features. The actual number of line or polygon features you can store in a shapefile depends on the number of vertices in each line or polygon (a vertex is equivalent to a point).
> — <cite>[Esri Documentation](https://desktop.arcgis.com/en/arcmap/latest/manage-data/shapefiles/geoprocessing-considerations-for-shapefile-output.htm#:~:text=There%20is%20a%202%20GB,roughly%2070%20million%20point%20features.)</cite>